### PR TITLE
Jbl/1036970 lax check for duplicate subblocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (htt
 # Note that the CMake-variables <Projectname>_VERSION_MAJOR, <Projectname>_VERSION_MINOR, ... are defined by this statement,
 #  which are used in the build (so that - if changing the name here, change also the usage of those variables).
 project ("czicompress"
-         VERSION 0.4.2)
+         VERSION 0.5.0)
 
 set(czicompress_VERSION_PATCH_FLAGS "-alpha")
 set(czicompress_VERSION_TWEAK_FLAGS "")
@@ -28,9 +28,10 @@ message (STATUS "[${PROJECT_NAME}] Processing ${CMAKE_CURRENT_LIST_FILE}")
 include(FetchContent)
 FetchContent_Declare(
   libczi
-  #GIT_REPOSITORY https://github.com/ZEISS/libczi.git
   GIT_REPOSITORY https://github.com/ptahmose/libczi-zeiss
   GIT_TAG  jbl/1036970-more_lax_checking_for_duplicte_subblocks
+  # ***** CHANGE BEFORE MERGING INTO MAINLINE *****
+  #GIT_REPOSITORY https://github.com/ZEISS/libczi.git
   #GIT_TAG        c9954d58759ef6dd7d7c6a53c163ea8349855392
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,11 +28,8 @@ message (STATUS "[${PROJECT_NAME}] Processing ${CMAKE_CURRENT_LIST_FILE}")
 include(FetchContent)
 FetchContent_Declare(
   libczi
-  GIT_REPOSITORY https://github.com/ptahmose/libczi-zeiss
-  GIT_TAG  jbl/1036970-more_lax_checking_for_duplicte_subblocks
-  # ***** CHANGE BEFORE MERGING INTO MAINLINE *****
-  #GIT_REPOSITORY https://github.com/ZEISS/libczi.git
-  #GIT_TAG        c9954d58759ef6dd7d7c6a53c163ea8349855392
+  GIT_REPOSITORY https://github.com/ZEISS/libczi.git
+  GIT_TAG        05bc1ebdca520ba2c5bfc3b9fcde76c548e98545
 )
 
 if(NOT libCZI_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (htt
 # Note that the CMake-variables <Projectname>_VERSION_MAJOR, <Projectname>_VERSION_MINOR, ... are defined by this statement,
 #  which are used in the build (so that - if changing the name here, change also the usage of those variables).
 project ("czicompress"
-         VERSION 0.4.1)
+         VERSION 0.4.2)
 
 set(czicompress_VERSION_PATCH_FLAGS "-alpha")
 set(czicompress_VERSION_TWEAK_FLAGS "")
@@ -28,8 +28,10 @@ message (STATUS "[${PROJECT_NAME}] Processing ${CMAKE_CURRENT_LIST_FILE}")
 include(FetchContent)
 FetchContent_Declare(
   libczi
-  GIT_REPOSITORY https://github.com/ZEISS/libczi.git
-  GIT_TAG        c9954d58759ef6dd7d7c6a53c163ea8349855392
+  #GIT_REPOSITORY https://github.com/ZEISS/libczi.git
+  GIT_REPOSITORY https://github.com/ptahmose/libczi-zeiss
+  GIT_TAG  jbl/1036970-more_lax_checking_for_duplicte_subblocks
+  #GIT_TAG        c9954d58759ef6dd7d7c6a53c163ea8349855392
 )
 
 if(NOT libCZI_POPULATED)

--- a/README.md
+++ b/README.md
@@ -49,8 +49,6 @@ Start the executable from the command line, providing the required command line 
 ```
 Usage: czicompress.exe [OPTIONS]
 
-  version: 0.4.2.0
-
 Options:
   -h,--help         Print this help message and exit
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ Clicking on these artifacts will download a ZIP file with the executable. The ex
 Start the executable from the command line, providing the required command line arguments.
 
 ```
-Usage: czicompress [OPTIONS]
+Usage: czicompress.exe [OPTIONS]
+
+  version: 0.4.2.0
 
 Options:
   -h,--help         Print this help message and exit
@@ -71,6 +73,13 @@ Options:
   -t,--compression_options COMPRESSION_OPTIONS
                     Specify compression parameters. The default is
                     'zstd1:ExplicitLevel=1;PreProcess=HiLoByteUnpack'.
+
+  -w,--overwrite    If the output file exists, try to overwrite it.
+
+  --ignore_duplicate_subblocks BOOLEAN
+                    If this option is enabled, the operation will ignore if
+                    duplicate subblocks are encountered in the source document.
+                    Otherwise, an error will be reported. The default is 'on'.
 
 
 Copies the content of a CZI-file into another CZI-file changing the compression

--- a/app/CZIcompress.cpp
+++ b/app/CZIcompress.cpp
@@ -98,10 +98,12 @@ int main(int argc, char** argv)
         libCZI::CreateOutputStreamForFile(utils::utf8::WidenUtf8(command_line_options.GetOutputFileName()).c_str(), false);
 
     // create the "CZI-writer"-object
-    const auto writer = libCZI::CreateCZIWriter();
+    libCZI::CZIWriterOptions czi_writer_options;
+    czi_writer_options.allow_duplicate_subblocks = true;
+    const auto writer = libCZI::CreateCZIWriter(&czi_writer_options);
 
     // GUID_NULL here means that a new Guid is created
-    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(GUID{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}});
+    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     // TODO(JBL): it might be desirable to make reservations for the
     //            subblock-directory-/attachments-directory-/metadata-segment

--- a/app/CZIcompress.cpp
+++ b/app/CZIcompress.cpp
@@ -95,11 +95,11 @@ int main(int argc, char** argv)
 
     // Create an "output-stream-object"
     const auto output_stream =
-        libCZI::CreateOutputStreamForFile(utils::utf8::WidenUtf8(command_line_options.GetOutputFileName()).c_str(), false);
+        libCZI::CreateOutputStreamForFile(utils::utf8::WidenUtf8(command_line_options.GetOutputFileName()).c_str(), command_line_options.GetOverwriteExistingFile());
 
-    // create the "CZI-writer"-object
+    // create (and configure) the "CZI-writer"-object
     libCZI::CZIWriterOptions czi_writer_options;
-    czi_writer_options.allow_duplicate_subblocks = true;
+    czi_writer_options.allow_duplicate_subblocks = command_line_options.GetIgnoreDuplicateSubblocks();
     const auto writer = libCZI::CreateCZIWriter(&czi_writer_options);
 
     // GUID_NULL here means that a new Guid is created

--- a/capi/capi.cpp
+++ b/capi/capi.cpp
@@ -46,10 +46,12 @@ public:
     open_options.ignore_sizem_for_pyramid_subblocks = true;
     reader->Open(stream, &open_options);
 
-    // create the "CZI-writer"-object
+    // create (and configure) the "CZI-writer"-object
     const std::string output_string(output_path);
     const auto output_stream = libCZI::CreateOutputStreamForFile(utils::utf8::WidenUtf8(output_string).c_str(), false);
 
+    libCZI::CZIWriterOptions czi_writer_options;
+    czi_writer_options.allow_duplicate_subblocks = true;
     const auto writer = libCZI::CreateCZIWriter();
 
     // GUID_NULL here means that a new Guid is created

--- a/capi/capi.cpp
+++ b/capi/capi.cpp
@@ -46,13 +46,14 @@ public:
     open_options.ignore_sizem_for_pyramid_subblocks = true;
     reader->Open(stream, &open_options);
 
-    // create (and configure) the "CZI-writer"-object
+    // create the stream-object representing the destination file
     const std::string output_string(output_path);
     const auto output_stream = libCZI::CreateOutputStreamForFile(utils::utf8::WidenUtf8(output_string).c_str(), false);
 
+    // create (and configure) the "CZI-writer"-object - it is configured to ignore "duplicate subblocks"
     libCZI::CZIWriterOptions czi_writer_options;
     czi_writer_options.allow_duplicate_subblocks = true;
-    const auto writer = libCZI::CreateCZIWriter();
+    const auto writer = libCZI::CreateCZIWriter(&czi_writer_options);
 
     // GUID_NULL here means that a new Guid is created
     const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}});

--- a/capi/capi.cpp
+++ b/capi/capi.cpp
@@ -53,7 +53,7 @@ public:
     const auto writer = libCZI::CreateCZIWriter();
 
     // GUID_NULL here means that a new Guid is created
-    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(GUID{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}});
+    const auto czi_writer_info = std::make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}});
 
     // TODO(JBL): it might be desirable to make reservations for the
     // subblock-directory-/attachments-directory-/metadata-segment

--- a/lib/include/commandlineoptions.h
+++ b/lib/include/commandlineoptions.h
@@ -99,7 +99,7 @@ public:
 
   /// Gets a boolean indicating whether the CZIWriter object should be configured to ignore duplicate subblocks.
   ///
-  /// \returns  True if duplicate subblocks are to be ignore (with the CZIWriter object); false otherwise.
+  /// \returns  True if duplicate subblocks are to be ignored (with the CZIWriter object); false otherwise.
   bool GetIgnoreDuplicateSubblocks() const { return this->ignore_duplicate_subblocks_; }
 
 private:

--- a/lib/include/commandlineoptions.h
+++ b/lib/include/commandlineoptions.h
@@ -29,7 +29,8 @@ private:
   std::string output_filename_;
   CompressionStrategy compression_strategy_{CompressionStrategy::kInvalid};
   libCZI::Utils::CompressionOption compression_option_;
-
+  bool overwrite_existing_file_{false};
+  bool ignore_duplicate_subblocks_{true};
 public:
   /// Values that represent the result of the "Parse"-operation.
   enum class ParseResult
@@ -90,6 +91,10 @@ public:
   ///
   /// \returns    The compression option.
   const libCZI::Utils::CompressionOption& GetCompressionOption() const { return this->compression_option_; }
+
+  bool GetOverwriteExistingFile() const { return this->overwrite_existing_file_; }
+
+  bool GetIgnoreDuplicateSubblocks() const { return this->ignore_duplicate_subblocks_; }
 
 private:
   static std::string GetFooterText();

--- a/lib/include/commandlineoptions.h
+++ b/lib/include/commandlineoptions.h
@@ -92,8 +92,14 @@ public:
   /// \returns    The compression option.
   const libCZI::Utils::CompressionOption& GetCompressionOption() const { return this->compression_option_; }
 
+  /// Gets a boolean indicating whether when creating the output file, it is to be overwritten if it already exists.
+  ///
+  /// \returns  True if an existing file is to be overwritten (if it exists); false otherwise.
   bool GetOverwriteExistingFile() const { return this->overwrite_existing_file_; }
 
+  /// Gets a boolean indicating whether the CZIWriter object should be configured to ignore duplicate subblocks.
+  ///
+  /// \returns  True if duplicate subblocks are to be ignore (with the CZIWriter object); false otherwise.
   bool GetIgnoreDuplicateSubblocks() const { return this->ignore_duplicate_subblocks_; }
 
 private:

--- a/tests/test_copyoperation.cpp
+++ b/tests/test_copyoperation.cpp
@@ -40,7 +40,7 @@ static tuple<shared_ptr<void>, size_t> CreateCziWithFourSubblockInMosaicArrangem
   auto writer = libCZI::CreateCZIWriter();
   auto outStream = make_shared<CMemOutputStream>(0);
 
-  auto spWriterInfo = make_shared<libCZI::CCziWriterInfo>(GUID{0x1234567, 0x89ab, 0xcdef, {1, 2, 3, 4, 5, 6, 7, 8}},  // NOLINT
+  auto spWriterInfo = make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0x1234567, 0x89ab, 0xcdef, {1, 2, 3, 4, 5, 6, 7, 8}},  // NOLINT
                                                           libCZI::CDimBounds{{libCZI::DimensionIndex::C, 0, 1}},      // set a bounds for C
                                                           0, 3);  // set a bounds M : 0<=m<=0
   writer->Create(outStream, spWriterInfo);
@@ -162,7 +162,7 @@ TEST_CASE("copyczi.1: run compression on simple synthetic document", "[copyczi]"
   // create a CZI-writer object on a new memory stream
   auto writer = libCZI::CreateCZIWriter();
   const auto memory_backed_stream_destination_document = make_shared<CMemInputOutputStream>(0);
-  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
+  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
   writer->Create(memory_backed_stream_destination_document, writer_info);
 
   // act
@@ -218,7 +218,7 @@ TEST_CASE("copyczi.2: run compression on simple synthetic document changes compr
   // create a CZI-writer object on a new memory stream
   auto writer = libCZI::CreateCZIWriter();
   const auto memory_backed_stream_destination_document = make_shared<CMemInputOutputStream>(0);
-  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
+  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
   writer->Create(memory_backed_stream_destination_document, writer_info);
 
   // act
@@ -280,7 +280,7 @@ TEST_CASE("copyczi.3: run decompression on simple synthetically compressed docum
   // create a CZI-writer object on a new memory stream
   auto writer = libCZI::CreateCZIWriter();
   const auto memory_backed_stream_destination_document = make_shared<CMemInputOutputStream>(0);
-  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
+  const auto writer_info = make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
   writer->Create(memory_backed_stream_destination_document, writer_info);
 
   // act
@@ -309,7 +309,7 @@ TEST_CASE("copyczi.3: run decompression on simple synthetically compressed docum
   // create a CZI-writer object on a new memory stream
   auto writer_2 = libCZI::CreateCZIWriter();
   const auto memory_backed_stream_destination_document_2 = make_shared<CMemInputOutputStream>(0);
-  const auto writer_info_2 = make_shared<libCZI::CCziWriterInfo>(GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
+  const auto writer_info_2 = make_shared<libCZI::CCziWriterInfo>(libCZI::GUID{0x0, 0x0, 0x0, {0, 0, 0, 0, 0, 0, 0, 0}});
   writer_2->Create(memory_backed_stream_destination_document_2, writer_info_2);
 
   // act


### PR DESCRIPTION
## Description

- Use a new option for the CZIWriter to ignore duplicate subblocks.
- The command line application is given a new option to enable/disable "ignoring duplicate subblocks". Default is "on".
- In the C-API layer, the option is enabled always.
- in addition, a new option allowing to overwrite an existing file is added to the command line application.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the documentation.
- [x] I updated the version of czicompress following [the README (Versioning)](../README.md#versioning) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
