### PR TITLE
Do not overwrite OriginalCompressionMethod anymore in czicompress

### DIFF
--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -51,16 +51,16 @@ jobs:
         id: getversion
         run: |
           $xml = [xml](Get-Content -Path "Directory.Build.props")
-          $version = $xml.SelectSingleNode('//VersionPrefix').'#text' + "-" + $xml.SelectSingleNode('//VersionSuffix').'#text'
+          $version = $xml.SelectSingleNode('//VersionPrefix').'#text'
           "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         shell: pwsh
 
       - name: Add build ID to version in Directory.Build.props
         run: |
-          Write-Output "Add build ID ${{ github.run_id }} to VersionSuffix in Directory.Build.props"
+          Write-Output "Add build ID ${{ github.run_id }} to VersionPrefix in Directory.Build.props"
           $file = Get-Item "Directory.Build.props"
           $xml = [xml](Get-Content -Path $file.FullName)
-          $versionElement = $xml.SelectSingleNode('//VersionSuffix')
+          $versionElement = $xml.SelectSingleNode('//VersionPrefix')
           $versionElement.'#text' += '+${{ github.run_id }}'
           $xml.Save($file.FullName)
         shell: pwsh

--- a/czicompress/CMakeLists.txt
+++ b/czicompress/CMakeLists.txt
@@ -9,9 +9,8 @@ cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (htt
 # Note that the CMake-variables <Projectname>_VERSION_MAJOR, <Projectname>_VERSION_MINOR, ... are defined by this statement,
 #  which are used in the build (so that - if changing the name here, change also the usage of those variables).
 project ("czicompress"
-         VERSION 0.5.1)
+         VERSION 0.5.2)
 
-set(czicompress_VERSION_PATCH_FLAGS "-alpha")
 set(czicompress_VERSION_TWEAK_FLAGS "")
 
 if(WIN32)

--- a/czicompress/CMakeLists.txt
+++ b/czicompress/CMakeLists.txt
@@ -11,6 +11,7 @@ cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (htt
 project ("czicompress"
          VERSION 0.5.2)
 
+set(czicompress_VERSION_PATCH_FLAGS "")
 set(czicompress_VERSION_TWEAK_FLAGS "")
 
 if(WIN32)

--- a/czicompress/lib/src/copyczi.cpp
+++ b/czicompress/lib/src/copyczi.cpp
@@ -378,12 +378,7 @@ std::shared_ptr<libCZI::ICziMetadataBuilder> CopyCziAndCompress::ModifyMetadata(
     auto metadata_src = metadata_segment->CreateMetaFromMetadataSegment();
     const auto metadata_builder = libCZI::CreateMetadataBuilderFromXml(metadata_src->GetXml());
 
-    metadata_builder->GetRootNode()
-        ->GetOrCreateChildNode("Metadata/Information/Image/OriginalCompressionMethod")
-        ->SetValue(this->compression_option_.first == libCZI::CompressionMode::Zstd0   ? "Zstd0"
-                   : this->compression_option_.first == libCZI::CompressionMode::Zstd1 ? "Zstd1"
-                                                                                       : "unknown");
-    metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/OriginalEncodingQuality")->SetValue("100");
+    metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/CurrentCompressionParameters")->SetValue("Lossless: True");
 
     return metadata_builder;
   }
@@ -411,8 +406,7 @@ std::shared_ptr<libCZI::ICziMetadataBuilder> CopyCziAndDecompress::ModifyMetadat
     auto metadata_src = metadata_segment->CreateMetaFromMetadataSegment();
     const auto metadata_builder = libCZI::CreateMetadataBuilderFromXml(metadata_src->GetXml());
 
-    metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/OriginalCompressionMethod")->SetValue("Uncompressed");
-    metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/OriginalEncodingQuality")->SetValue("100");
+    metadata_builder->GetRootNode()->GetOrCreateChildNode("Metadata/Information/Image/CurrentCompressionParameters")->SetValue("");
 
     return metadata_builder;
   }

--- a/czicompress/tests/test_copyoperation.cpp
+++ b/czicompress/tests/test_copyoperation.cpp
@@ -247,18 +247,14 @@ TEST_CASE("copyczi.2: run compression on simple synthetic document changes compr
   auto metadata_segment = reader_compressed_document->ReadMetadataSegment();
   auto metadata = metadata_segment->CreateMetaFromMetadataSegment();
 
-  auto compression_method = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/OriginalCompressionMethod");
-  std::wstring compression_method_string;
-  bool success = compression_method->TryGetValue(&compression_method_string);
-  REQUIRE(success == true);
-  REQUIRE(compression_method_string == std::wstring(L"Zstd1"));
+  auto first_subblock = reader_compressed_document->ReadSubBlock(0);
+  auto compression_method = first_subblock->GetSubBlockInfo().GetCompressionMode();
+  REQUIRE(compression_method == libCZI::CompressionMode::Zstd1);
 
-  std::wstring compression_level;
-  auto encoding_quality = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/OriginalEncodingQuality");
-  std::wstring encoding_quality_string;
-  success = encoding_quality->TryGetValue(&encoding_quality_string);
-  REQUIRE(success == true);
-  REQUIRE(encoding_quality_string == std::wstring(L"100"));
+  auto compression_parameters = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/CurrentCompressionParameters");
+  std::wstring compression_parameters_string;
+  bool success = compression_parameters->TryGetValue(&compression_parameters_string);
+  REQUIRE(compression_parameters_string == std::wstring(L"Lossless: True"));
 }
 
 
@@ -331,17 +327,12 @@ TEST_CASE("copyczi.3: run decompression on simple synthetically compressed docum
   auto metadata_segment = reader_decompressed_document->ReadMetadataSegment();
   auto metadata = metadata_segment->CreateMetaFromMetadataSegment();
 
-  auto compression_method = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/OriginalCompressionMethod");
-  auto xml = metadata->GetXml();
-  std::wstring compression_method_string;
-  bool success = compression_method->TryGetValue(&compression_method_string);
-  REQUIRE(success == true);
-  REQUIRE(compression_method_string == std::wstring(L"Uncompressed"));
+  auto first_subblock = reader_decompressed_document->ReadSubBlock(0);
+  auto compression_method = first_subblock->GetSubBlockInfo().GetCompressionMode();
+  REQUIRE(compression_method == libCZI::CompressionMode::UnCompressed);
 
-  std::wstring compression_level;
-  auto encoding_quality = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/OriginalEncodingQuality");
-  std::wstring encoding_quality_string;
-  success = encoding_quality->TryGetValue(&encoding_quality_string);
-  REQUIRE(success == true);
-  REQUIRE(encoding_quality_string == std::wstring(L"100"));
+  auto compression_parameters = metadata->GetChildNodeReadonly("ImageDocument/Metadata/Information/Image/CurrentCompressionParameters");
+  std::wstring compression_parameters_string;
+  bool success = compression_parameters->TryGetValue(&compression_parameters_string);
+  REQUIRE(success == false); // in case of uncompressed, the metadata is empty, i.e. <CurrentCompressionParameters />, so getting its value fails.
 }

--- a/czishrink/Directory.Build.props
+++ b/czishrink/Directory.Build.props
@@ -11,6 +11,5 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Version -->
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>alpha.46<!--feature/add-czishrink--></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
+++ b/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
@@ -18,7 +18,7 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().ToString();
 
         // ASSERT
-        var re = new Regex(@"^CZI Shrink 1\.0\.0-alpha\.[1-9]\d\d*(\+\d+)?$");
+        var re = new Regex(@"^CZI Shrink 1\.0\.0(\+\d+)?$");
         re.IsMatch(actual).Should().BeTrue();
     }
 
@@ -39,7 +39,7 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().Version;
 
         // ASSERT
-        var re = new Regex(@"^1\.0\.0-alpha\.[1-9]\d\d*(\+\d+)?$");
+        var re = new Regex(@"^1\.0\.0(\+\d+)?$");
         re.IsMatch(actual).Should().BeTrue();
     }
 }

--- a/czishrink/upgrade-libczicompressc.ps1
+++ b/czishrink/upgrade-libczicompressc.ps1
@@ -296,15 +296,15 @@ $NewVersionTuple="($($NewFileVersion.Major), $($NewFileVersion.Minor))"
 $AlteredSourceCode = $SourceCode -replace '^( *\(int Major, int Minor\) expected = ).*?;$',('$1' + $NewVersionTuple + ";")
 Set-Content -Path netczicompress/Models/PInvokeFileProcessor.cs -Value $AlteredSourceCode
 
-# Increment VersionSuffix
-Write-Output "INFO: Incrementing VersionSuffix in Directory.Build.props"
+# Increment VersionPrefix
+Write-Output "INFO: Incrementing VersionPrefix in Directory.Build.props"
 $file = Get-Item "Directory.Build.props"
 $xml = [xml](Get-Content -Path $file.FullName)
-$versionElement = $xml.SelectSingleNode('//VersionSuffix')
+$versionElement = $xml.SelectSingleNode('//VersionPrefix')
 $VersionTokens = $versionElement.'#text'.split(".")
 $versionElement.'#comment' = $BranchName
 $VersionTokens[1] = [string]([int]($VersionTokens.split(".")[1]) + 1)
-$versionElement.'#text' = "$($VersionTokens[0]).$($VersionTokens[1])"
+$versionElement.'#text' = "$($VersionTokens[0]).$($VersionTokens[1]).$($VersionTokens[2])"
 $xml.Save($file.FullName)
 
 # Git commit everything


### PR DESCRIPTION
## Description

In the past we accidently used the OriginalCompressionMethod to also store the "current" compression method, although it should be only used to store the compression method at the time of the acquisition.
This PR fixes this issue and uses the newly introduced metadata "CurrentCompressionParameters" and "OriginalCompressionParameters" while ignoring the "OriginalEncodingQuality" metadata.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I tested my changes by automated unit tests.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of czicompress following [the README (Versioning)](../README.md#versioning) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
