### PR TITLE
Fix CziShrink versioning

### DIFF
--- a/czishrink/Directory.Build.props
+++ b/czishrink/Directory.Build.props
@@ -10,6 +10,6 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <!-- Version -->
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.0.1<!--fix/version-stuff--></VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
+++ b/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
@@ -18,8 +18,7 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().ToString();
 
         // ASSERT
-        var re = new Regex(@"^CZI Shrink 1\.0\.0(\+\d+)?$");
-        re.IsMatch(actual).Should().BeTrue();
+        actual.Should().MatchRegex(@"^CZI Shrink 1\.0\.\d+(\+\d+)?$");
     }
 
     [Fact]
@@ -39,7 +38,6 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().Version;
 
         // ASSERT
-        var re = new Regex(@"^1\.0\.0(\+\d+)?$");
-        re.IsMatch(actual).Should().BeTrue();
+        actual.Should().MatchRegex(@"^1\.0\.\d+(\+\d+)?$");
     }
 }


### PR DESCRIPTION
## Description

Fix versioning of CziShrink to work for non-alpha versions. 

Note that VersionSuffix is always appended to VersionPrefix with a hyphen (which indicates Prerelease according to semver) so we now always leave it unset. 

The new version for CziShrink must now be set by the user when upgrading the libczicompressc library, as we cannot determine automatically what the correct new version should be.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

* Built, ran tests, ran upgrade script

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the version of czishrink (PATCH)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
