### PR TITLE
Switch to dotnet8 for compilation and target framework

### DIFF
--- a/.github/workflows/czishrink_codeql.yml
+++ b/.github/workflows/czishrink_codeql.yml
@@ -42,6 +42,14 @@ jobs:
         with:
           dotnet-version: 8.0.x
 
+      - name: Cache nugets
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.nuget/packages
+          key: ${{ runner.os }}-czishrink-nuget-${{ hashFiles('czishrink/**/packages.lock.json') }}
+          restore-keys: |
+              ${{ runner.os }}-czishrink-nuget-
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
@@ -49,7 +57,7 @@ jobs:
           queries: security-and-quality
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore --locked-mode
 
       - name: Build
         run: dotnet build --no-restore -c Release

--- a/.github/workflows/czishrink_codeql.yml
+++ b/.github/workflows/czishrink_codeql.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -121,7 +121,6 @@ jobs:
         run: >
           dotnet publish netczicompress.Desktop/netczicompress.Desktop.csproj
           -c ${{ matrix.build }}
-          -a x64
           --no-restore
           --self-contained
           -p:PublishSingleFile=true

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -117,7 +117,7 @@ jobs:
         if: ${{ always() }}
 
       - name: Publish
-        if: ${{ (github.event_name == 'push') && (matrix.build == 'Release') }}
+        if: matrix.build == 'Release'
         run: >
           dotnet publish netczicompress.Desktop/netczicompress.Desktop.csproj
           -c ${{ matrix.build }}

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 7.0.x
+          dotnet-version: 8.0.x
 
       - name: Get Version from Directory.Build.props
         id: getversion

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -121,7 +121,7 @@ jobs:
         run: >
           dotnet publish netczicompress.Desktop/netczicompress.Desktop.csproj
           -c ${{ matrix.build }}
-          --no-restore
+          -a x64
           --self-contained
           -p:PublishSingleFile=true
           -p:PublishReadyToRun=true

--- a/czishrink/.vscode/launch.json
+++ b/czishrink/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/netczicompress.Desktop/bin/x64/Debug/net7.0/CziShrink",
+            "program": "${workspaceFolder}/netczicompress.Desktop/bin/x64/Debug/net8.0/CziShrink",
             "args": [],
             "cwd": "${workspaceFolder}/netczicompress.Desktop",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/czishrink/Directory.Build.props
+++ b/czishrink/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <MSBuildCopyContentTransitively>True</MSBuildCopyContentTransitively>
@@ -17,6 +17,6 @@
 
     <!-- Version -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>1.0.3<!--dependabot/nuget/czishrink/Microsoft.Extensions.Logging.Abstractions-8.0.0--></VersionPrefix>
+    <VersionPrefix>1.1.0<!--feature/dotnet8--></VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/czishrink/global.json
+++ b/czishrink/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "7.0.0",
+      "version": "8.0.0",
       "allowPrerelease": false,
       "rollForward": "latestFeature"
     }

--- a/czishrink/netczicompress.Desktop/packages.lock.json
+++ b/czishrink/netczicompress.Desktop/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net7.0": {
+    "net8.0": {
       "Avalonia.Desktop": {
         "type": "Direct",
         "requested": "[11.0.5, )",

--- a/czishrink/netczicompress/Models/CompositeObserver.cs
+++ b/czishrink/netczicompress/Models/CompositeObserver.cs
@@ -20,15 +20,9 @@ public static class CompositeObserver
     /// A composite <see cref="IObserver{T}"/>.
     /// </summary>
     /// <typeparam name="T">The observed type.</typeparam>
-    public sealed class CompositeObserverImpl<T> : IObserver<T>
+    public sealed class CompositeObserverImpl<T>(params IObserver<T>[] observers)
+        : IObserver<T>
     {
-        private readonly IObserver<T>[] observers;
-
-        public CompositeObserverImpl(params IObserver<T>[] observers)
-        {
-            this.observers = observers;
-        }
-
         public void OnCompleted()
         {
             this.ForEachObserver(o => o.OnCompleted());
@@ -46,7 +40,7 @@ public static class CompositeObserver
 
         private void ForEachObserver(Action<IObserver<T>> action)
         {
-            foreach (var item in this.observers)
+            foreach (var item in observers)
             {
                 action(item);
             }

--- a/czishrink/netczicompress/Models/CompressionLevel.cs
+++ b/czishrink/netczicompress/Models/CompressionLevel.cs
@@ -39,7 +39,7 @@ public record CompressionLevel
     public static int DefaultValue { get; } = 1;
 
     [Range(0, 22)]
-    public int Value
+    public required int Value
     {
         get => this.internalValue;
         init =>

--- a/czishrink/netczicompress/Models/CsvLoggingStrategy.cs
+++ b/czishrink/netczicompress/Models/CsvLoggingStrategy.cs
@@ -12,14 +12,9 @@ using System.Reactive.Concurrency;
 /// <summary>
 /// A logging strategy that writes data to a CSV log file.
 /// </summary>
-public class CsvLoggingStrategy : ILoggingStrategy
+public class CsvLoggingStrategy(IFileLauncher fileLauncher) : ILoggingStrategy
 {
-    private readonly IFileLauncher fileLauncher;
-
-    public CsvLoggingStrategy(IFileLauncher fileLauncher)
-    {
-        this.fileLauncher = fileLauncher;
-    }
+    private readonly IFileLauncher fileLauncher = fileLauncher;
 
     /// <summary>
     /// Gets the scheduler to use for logging.

--- a/czishrink/netczicompress/Models/FileLauncher.cs
+++ b/czishrink/netczicompress/Models/FileLauncher.cs
@@ -11,7 +11,7 @@ using System.IO.Abstractions;
 /// Launches a file with its associated app,
 /// or displays a file in its folder with the operating system's file manager.
 /// </summary>
-public class FileLauncher : IFileLauncher
+public class FileLauncher(IFileSystem fs, Func<string, string?> getEnvironmentVariable) : IFileLauncher
 {
     // Cf. https://github.com/dotnet/runtime/blob/52806bc157decf345005249c9ea7969c8b9e7e1b/src/libraries/System.Private.CoreLib/src/System/OperatingSystem.cs#L14C9-L41C6
     private const string Windows = "WINDOWS";
@@ -23,23 +23,14 @@ public class FileLauncher : IFileLauncher
 
     private const string Unsupported = "UNSUPPORTED";
     private static readonly string[] SupportedPlatforms =
-        {
+        [
             Windows,
             Osx,
             Linux,
             FreeBsd,
             NetBsd,
             Solaris,
-        };
-
-    private readonly IFileSystem fs;
-    private readonly Func<string, string?> getEnvironmentVariable;
-
-    public FileLauncher(IFileSystem fs, Func<string, string?> getEnvironmentVariable)
-    {
-        this.fs = fs;
-        this.getEnvironmentVariable = getEnvironmentVariable;
-    }
+        ];
 
     protected string CurrentPlatform { get; init; } = GetPlatform();
 
@@ -100,10 +91,10 @@ public class FileLauncher : IFileLauncher
     private ProcessStartInfo GetRevealStartInfoWindows(string path)
     {
         var fileName = "explorer";
-        var sysRoot = this.getEnvironmentVariable("SYSTEMROOT");
+        var sysRoot = getEnvironmentVariable("SYSTEMROOT");
         if (sysRoot != null)
         {
-            fileName = this.fs.Path.Combine(sysRoot, fileName);
+            fileName = fs.Path.Combine(sysRoot, fileName);
         }
 
         return new ProcessStartInfo
@@ -126,7 +117,7 @@ public class FileLauncher : IFileLauncher
 
     private ProcessStartInfo GetOpenParentFolderStartInfo(string path)
     {
-        return GetLaunchStartInfo(this.fs.Path.GetDirectoryName(path));
+        return GetLaunchStartInfo(fs.Path.GetDirectoryName(path));
     }
 
     private ProcessStartInfo GetRevealStartInfo(string path)

--- a/czishrink/netczicompress/Models/ObservableMixin.CompleteOnError.cs
+++ b/czishrink/netczicompress/Models/ObservableMixin.CompleteOnError.cs
@@ -26,18 +26,11 @@ public static partial class ObservableMixin
         return new CompleteOnErrorDecorator<T>(obs);
     }
 
-    public class CompleteOnErrorDecorator<T> : IObservable<T>
+    public class CompleteOnErrorDecorator<T>(IObservable<T> core) : IObservable<T>
     {
-        private readonly IObservable<T> core;
-
-        public CompleteOnErrorDecorator(IObservable<T> core)
-        {
-            this.core = core;
-        }
-
         public IDisposable Subscribe(IObserver<T> observer)
         {
-            return this.core.Subscribe(
+            return core.Subscribe(
                 onNext: observer.OnNext,
                 onCompleted: observer.OnCompleted,
                 onError: ex => observer.OnCompleted());

--- a/czishrink/netczicompress/Models/PInvokeFileProcessor.cs
+++ b/czishrink/netczicompress/Models/PInvokeFileProcessor.cs
@@ -118,10 +118,7 @@ public sealed partial class PInvokeFileProcessor : IFileProcessor
 
     private void CheckDisposed()
     {
-        if (this.IsDisposed)
-        {
-            throw new ObjectDisposedException(this.ToString());
-        }
+        ObjectDisposedException.ThrowIf(this.IsDisposed, this);
     }
 
     internal static partial class NativeMethods
@@ -199,7 +196,7 @@ public sealed partial class PInvokeFileProcessor : IFileProcessor
 
         [LibraryImport(LibName, StringMarshalling = LibStringEncoding)]
         [return: MarshalAs(UnmanagedType.U1)]
-        public static partial bool GetLibVersionString(byte[] buffer, ref ulong bufferLength);
+        public static partial bool GetLibVersionString([Out] byte[] buffer, ref ulong bufferLength);
 
         [LibraryImport(LibName, StringMarshalling = LibStringEncoding)]
         public static partial void GetLibVersion(out int major, out int minor, out int patch);
@@ -215,7 +212,7 @@ public sealed partial class PInvokeFileProcessor : IFileProcessor
             IntPtr file_processor,
             string input_path,
             string output_path,
-            byte[] error_message,
+            [Out] byte[] error_message,
             ref int error_message_length,
             ReportProgressCheckCancel reportProgress);
     }

--- a/czishrink/netczicompress/Models/StatisticsRunObserver.cs
+++ b/czishrink/netczicompress/Models/StatisticsRunObserver.cs
@@ -11,38 +11,28 @@ using System.Reactive.Linq;
 /// <summary>
 /// An <see cref="IFolderCompressorRunObserver{TMessage}"/> that forwards <see cref="AggregateStatistics"/> to an observer of these.
 /// </summary>
-public class StatisticsRunObserver : IFolderCompressorRunObserver<CompressorMessage.FileFinished>
-{
-    private readonly IObserver<AggregateStatistics> statisticsObserver;
-    private readonly TimeSpan samplingInterval;
-    private readonly IScheduler scheduler;
-
-    public StatisticsRunObserver(
+public class StatisticsRunObserver(
         IObserver<AggregateStatistics> statisticsObserver,
         TimeSpan samplingInterval,
         IScheduler scheduler)
-    {
-        this.statisticsObserver = statisticsObserver;
-        this.samplingInterval = samplingInterval;
-        this.scheduler = scheduler;
-    }
-
+    : IFolderCompressorRunObserver<CompressorMessage.FileFinished>
+{
     public void ObserveRun(FolderCompressorParameters runParameters, IObservable<CompressorMessage.FileFinished> runMessages)
     {
-        var start = this.scheduler.Now;
+        var start = scheduler.Now;
 
         var emptyStats = AggregateStatistics.Empty;
-        this.statisticsObserver.OnNext(emptyStats);
+        statisticsObserver.OnNext(emptyStats);
         var cumulativeStatistics = runMessages
             .CompleteOnError()
             .Scan(
                 emptyStats,
-                (stats, msg) => stats.AddData(msg, this.scheduler.Now - start));
+                (stats, msg) => stats.AddData(msg, scheduler.Now - start));
 
         // Subscriptions will expire upon completion, no need for explicit disposal.
         _ = cumulativeStatistics
-            .Sample(this.samplingInterval)
-            .ObserveOn(this.scheduler)
-            .Subscribe(this.statisticsObserver);
+            .Sample(samplingInterval)
+            .ObserveOn(scheduler)
+            .Subscribe(statisticsObserver);
     }
 }

--- a/czishrink/netczicompress/Models/TemporaryFile.cs
+++ b/czishrink/netczicompress/Models/TemporaryFile.cs
@@ -27,13 +27,13 @@ public class TemporaryFile
     /// immediately created, if possible.
     /// By this <see cref="TemporaryFileCreationFailed"/> is set accordingly.
     /// </summary>
-    /// <param name="outfile">The basic output file name.</param>
+    /// <param name="outFile">The basic output file name.</param>
     /// <param name="maxNumberOfTriesToCreate">The maximum number or tries.</param>
     public TemporaryFile(
-        IFileInfo outfile,
+        IFileInfo outFile,
         int maxNumberOfTriesToCreate = 100)
     {
-        this.OutFile = outfile;
+        this.OutFile = outFile;
         this.MaxNumberOfTriesToCreate = maxNumberOfTriesToCreate;
         this.Info = this.TryCreate();
     }

--- a/czishrink/netczicompress/Models/ThreadCount.cs
+++ b/czishrink/netczicompress/Models/ThreadCount.cs
@@ -25,7 +25,7 @@ public partial record ThreadCount
     /// </summary>
     public static int DefaultValue { get; } = Maximum;
 
-    public int Value
+    public required int Value
     {
         get => this.internalValue;
         init =>

--- a/czishrink/netczicompress/ViewModels/AggregateStatisticsViewModel.cs
+++ b/czishrink/netczicompress/ViewModels/AggregateStatisticsViewModel.cs
@@ -100,22 +100,23 @@ public class AggregateStatisticsViewModel : ViewModelBase, IObserver<AggregateSt
             // call measure once with infinity so that we get the "desired size" populated
             control.Measure(Size.Infinity);
             var size = control.DesiredSize;
+            int width = (int)size.Width;
+            int height = (int)size.Height;
+            size = new Size(width, height);
 
             control.Measure(size);
             control.Arrange(new Rect(size));
 
-            using (RenderTargetBitmap bitmap = new RenderTargetBitmap(new PixelSize(Convert.ToInt32(size.Width), Convert.ToInt32(size.Height))))
+            using var bitmap = new RenderTargetBitmap(new PixelSize(width, height));
+            bitmap.Render(control);
+            try
             {
-                bitmap.Render(control);
-                try
-                {
-                    this.clipboardHelper.PutBitmapIntoClipboard(bitmap);
-                    this.BadgeCopiedToClipboardRaised?.Invoke();
-                }
-                catch (Exception exception)
-                {
-                    this.logger.LogError(exception, "putting badge into clipboard failed: {ex}", exception);
-                }
+                this.clipboardHelper.PutBitmapIntoClipboard(bitmap);
+                this.BadgeCopiedToClipboardRaised?.Invoke();
+            }
+            catch (Exception exception)
+            {
+                this.logger.LogError(exception, "putting badge into clipboard failed: {ex}", exception);
             }
         }
     }

--- a/czishrink/netczicompress/ViewModels/Converters/BytesToStringConverter.cs
+++ b/czishrink/netczicompress/ViewModels/Converters/BytesToStringConverter.cs
@@ -15,7 +15,8 @@ public class BytesToStringConverter : ForwardOnlyConverter
 {
     // See: https://en.wikipedia.org/wiki/Kilobyte
     // Made the array future-proof in any case.
-    private static readonly string[] Sizes = { "bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB", "RB", "QB" };
+    private static readonly string[] Sizes =
+        ["bytes", "kB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB", "RB", "QB"];
 
     public override object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {

--- a/czishrink/netczicompress/packages.lock.json
+++ b/czishrink/netczicompress/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net7.0": {
+    "net8.0": {
       "Avalonia": {
         "type": "Direct",
         "requested": "[11.0.5, )",
@@ -84,6 +84,12 @@
           "Markdown.Avalonia.Tight": "11.0.2"
         }
       },
+      "Microsoft.DotNet.ILCompiler": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "zuTbpcWDCCvESnOAvpHuwum1C3jJIeDl+grYcRDqyoHsPAUutIB6wb7iJV3Y2Q96crKC6cObqf92eOVEiG7keQ=="
+      },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -92,6 +98,12 @@
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
         }
+      },
+      "Microsoft.NET.ILLink.Tasks": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "B3etT5XQ2nlWkZGO2m/ytDYrOmSsQG1XNBaM6ZYlX5Ch/tDrMFadr0/mK6gjZwaQc55g+5+WZMw4Cz3m8VEF7g=="
       },
       "Projektanker.Icons.Avalonia.FontAwesome": {
         "type": "Direct",

--- a/czishrink/netczicompressTests/Models/CompressionLevelTests.cs
+++ b/czishrink/netczicompressTests/Models/CompressionLevelTests.cs
@@ -10,9 +10,9 @@ namespace netczicompressTests.Models;
 public class CompressionLevelTests
 {
     [Fact]
-    public void DefaultConstructor_HasDefaultValue()
+    public void Default_HasDefaultValue()
     {
-        var sut = new CompressionLevel();
+        var sut = CompressionLevel.Default;
         sut.Value.Should().Be(CompressionLevel.DefaultValue);
     }
 

--- a/czishrink/netczicompressTests/Models/PInvokeFileProcessorTests.cs
+++ b/czishrink/netczicompressTests/Models/PInvokeFileProcessorTests.cs
@@ -17,7 +17,7 @@ public class PInvokeFileProcessorTests
     [Fact]
     public void Ctr_WhenCalledWithNoOp_Throws()
     {
-        Action act = () => _ = new PInvokeFileProcessor(CompressionMode.NoOp, new ProcessingOptions(new CompressionLevel()));
+        Action act = () => _ = new PInvokeFileProcessor(CompressionMode.NoOp, new ProcessingOptions(new CompressionLevel { Value = CompressionLevel.DefaultValue }));
 
         act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("mode");
     }
@@ -39,10 +39,10 @@ public class PInvokeFileProcessorTests
         using var deleteUncompressed = Disposable.Create(() => File.Delete(uncompressed));
 
         // ACT
-        using var compressor = new PInvokeFileProcessor(mode, new ProcessingOptions(new CompressionLevel()));
+        using var compressor = new PInvokeFileProcessor(mode, new ProcessingOptions(CompressionLevel.Default));
         compressor.ProcessFile(testFile, compressed, _ => { }, CancellationToken.None);
 
-        using var decompressor = new PInvokeFileProcessor(CompressionMode.Decompress, new ProcessingOptions(new CompressionLevel()));
+        using var decompressor = new PInvokeFileProcessor(CompressionMode.Decompress, new ProcessingOptions(CompressionLevel.Default));
         decompressor.ProcessFile(compressed, uncompressed, _ => { }, CancellationToken.None);
 
         var compressedSize = GetLength(compressed);
@@ -67,7 +67,7 @@ public class PInvokeFileProcessorTests
     public void NeedsExistingOutputDirectory_ShouldBeTrue(
         CompressionMode mode)
     {
-        using var target = new PInvokeFileProcessor(mode, new ProcessingOptions(new CompressionLevel()));
+        using var target = new PInvokeFileProcessor(mode, new ProcessingOptions(CompressionLevel.Default));
         target.NeedsExistingOutputDirectory.Should().BeTrue();
     }
 
@@ -86,7 +86,7 @@ public class PInvokeFileProcessorTests
         using var deleteCompressed = DeleteLater(compressed);
 
         // ACT
-        using var compressor = PInvokeFileProcessor.Create(mode, new ProcessingOptions(new CompressionLevel()));
+        using var compressor = PInvokeFileProcessor.Create(mode, new ProcessingOptions(CompressionLevel.Default));
         var token = new CancellationToken(true);
         Action act = () => compressor.ProcessFile(testFile, compressed, _ => { }, token);
 
@@ -105,7 +105,7 @@ public class PInvokeFileProcessorTests
         CompressionMode mode)
     {
         // ARRANGE
-        using var compressor = PInvokeFileProcessor.Create(mode, new ProcessingOptions(new CompressionLevel()));
+        using var compressor = PInvokeFileProcessor.Create(mode, new ProcessingOptions(CompressionLevel.Default));
         compressor.Dispose();
 
         Action act = () => compressor.ProcessFile("foo", "bar", _ => { }, CancellationToken.None);
@@ -139,13 +139,13 @@ public class PInvokeFileProcessorTests
         // ACT
         using var compressor = new PInvokeFileProcessor(
             CompressionMode.CompressAll,
-            new ProcessingOptions(new CompressionLevel()
+            new ProcessingOptions(new CompressionLevel
             {
                 Value = compressionLevel,
             }));
         compressor.ProcessFile(testFile, compressed, _ => { }, CancellationToken.None);
 
-        using var decompressor = new PInvokeFileProcessor(CompressionMode.Decompress, new ProcessingOptions(new CompressionLevel()));
+        using var decompressor = new PInvokeFileProcessor(CompressionMode.Decompress, new ProcessingOptions(CompressionLevel.Default));
         decompressor.ProcessFile(compressed, uncompressed, _ => { }, CancellationToken.None);
 
         var compressedSize = GetLength(compressed);

--- a/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
+++ b/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
@@ -4,8 +4,6 @@
 
 namespace netczicompressTests.Models;
 
-using System.Text.RegularExpressions;
-
 /// <summary>
 /// Tests for <see cref="ProgramNameAndVersion"/>.
 /// </summary>

--- a/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
+++ b/czishrink/netczicompressTests/Models/ProgramNameAndVersionTests.cs
@@ -18,7 +18,7 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().ToString();
 
         // ASSERT
-        actual.Should().MatchRegex(@"^CZI Shrink 1\.0\.\d+(\+\d+)?$");
+        actual.Should().MatchRegex(@"^CZI Shrink 1\.1\.\d+(\+\d+)?$");
     }
 
     [Fact]
@@ -38,6 +38,6 @@ public class ProgramNameAndVersionTests
         var actual = new ProgramNameAndVersion().Version;
 
         // ASSERT
-        actual.Should().MatchRegex(@"^1\.0\.\d+(\+\d+)?$");
+        actual.Should().MatchRegex(@"^1\.1\.\d+(\+\d+)?$");
     }
 }

--- a/czishrink/netczicompressTests/Models/ThreadCountTests.cs
+++ b/czishrink/netczicompressTests/Models/ThreadCountTests.cs
@@ -10,9 +10,9 @@ namespace netczicompressTests.Models;
 public class ThreadCountTests
 {
     [Fact]
-    public void DefaultConstructor_HasDefaultValue()
+    public void Default_HasDefaultValue()
     {
-        var sut = new ThreadCount();
+        var sut = ThreadCount.Default;
         sut.Value.Should().Be(ThreadCount.DefaultValue);
     }
 
@@ -31,7 +31,7 @@ public class ThreadCountTests
     [InlineData(1)]
     public void InRangeValue_ShouldBeEqual(int value)
     {
-        var sut = new ThreadCount() { Value = value };
+        var sut = new ThreadCount { Value = value };
         sut.Value.Should().Be(value);
     }
 }

--- a/czishrink/netczicompressTests/packages.lock.json
+++ b/czishrink/netczicompressTests/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "dependencies": {
-    "net7.0": {
+    "net8.0": {
       "AutoFixture": {
         "type": "Direct",
         "requested": "[4.18.0, )",


### PR DESCRIPTION
## Description

* Switch to .NET 8 and C#12.
* Use the nuget cache introduced in #24 also for CodeQl
* Set version to 1.1.0
* Note that StyleCop.Analyzers is not up to date with C#12 yet and complains about ' = ['. Workaround is to use a line break instead of the second space.

Fixes #27 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

* PR build with unit tests
* manual test

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I updated the version of czishrink (MINOR), new version is 1.1.0
- [x] New and existing unit tests pass locally with my changes.
