### PR TITLE
Add path-filtering for PRs

### DIFF
--- a/.github/workflows/czicompress_cmake.yml
+++ b/.github/workflows/czicompress_cmake.yml
@@ -10,9 +10,15 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  changes:
+    uses: ./.github/workflows/subproject-changes.yml
+
   build-tests:
+    needs: changes
+    if: ${{ needs.changes.outputs.czicompress  == 'true' }}
     defaults:
       run:
         working-directory: ${{github.workspace}}/czicompress

--- a/.github/workflows/czicompress_codeql.yml
+++ b/.github/workflows/czicompress_codeql.yml
@@ -14,9 +14,15 @@ permissions:
   actions: read
   contents: read
   security-events: write
+  pull-requests: read
 
 jobs:
+  changes:
+    uses: ./.github/workflows/subproject-changes.yml
+
   analyze:
+    needs: changes
+    if: ${{ needs.changes.outputs.czicompress  == 'true' }}
     name: Analyze CPP
     defaults:
       run:

--- a/.github/workflows/czishrink_codeql.yml
+++ b/.github/workflows/czishrink_codeql.yml
@@ -22,7 +22,12 @@ on:
 permissions: read-all
 
 jobs:
+  changes:
+    uses: ./.github/workflows/subproject-changes.yml
+
   analyze:
+    needs: changes
+    if: ${{ needs.changes.outputs.czishrink == 'true' }}
     name: Analyze CziShrink
     defaults:
       run:

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -15,7 +15,12 @@ on:
   workflow_dispatch: {}
 
 jobs:
+  changes:
+    uses: ./.github/workflows/subproject-changes.yml
+
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.czishrink == 'true' }}
     defaults:
       run:
         working-directory: czishrink

--- a/.github/workflows/subproject-changes.yml
+++ b/.github/workflows/subproject-changes.yml
@@ -1,0 +1,51 @@
+---
+# A reusable workflow that is used to detect whether code changes
+# are relevant for czishrink and/or czicompress.
+# See
+#  - https://github.com/dorny/paths-filter#examples
+#  - https://docs.github.com/en/actions/using-workflows/reusing-workflows
+name: subproject-changes
+
+# Required permissions
+permissions:
+  pull-requests: read
+
+on:
+  workflow_call:
+    outputs:
+      czishrink:
+        description: "'true' if the change affects czishrink or if github.event_name is not 'pull_request'; 'false' otherwise"
+        value: ${{ jobs.detect_changes.outputs.czishrink }}
+      czicompress:
+        description: "'true' if the change affects czicompress or if github.event_name is not 'pull_request'; 'false' otherwise"
+        value: ${{ jobs.detect_changes.outputs.czicompress }}
+
+jobs:
+  # JOB to run change detection
+  detect_changes:
+    runs-on: ubuntu-latest
+    # Set job outputs to values from filter step for PRs, and true for other events.
+    outputs:
+      czishrink: ${{ steps.result.outputs.czishrink }}
+      czicompress: ${{ steps.result.outputs.czicompress }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      - uses: dorny/paths-filter@v2
+        if: ${{ github.event_name == 'pull_request' }}
+        id: filter
+        with:
+          filters: |
+            czishrink:
+              - 'czishrink/**'
+              - '.github/**'
+              - '*.yml'
+            czicompress:
+              - '**czicompress**'
+              - '.github/**'
+              - '*.yml'
+      - id: result
+        run: |
+          echo "czishrink=${{ github.event_name != 'pull_request' || steps.filter.outputs.czishrink == 'true' }}"
+          echo "czicompress=${{ github.event_name != 'pull_request' || steps.filter.outputs.czicompress == 'true' }}"
+          echo "czishrink=${{ github.event_name != 'pull_request' || steps.filter.outputs.czishrink == 'true' }}" >> "$GITHUB_OUTPUT"
+          echo "czicompress=${{ github.event_name != 'pull_request' || steps.filter.outputs.czicompress == 'true' }}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# CURRENTLY NOT WORKING
This seems to have the fundamental issue that individual _jobs_ are required as status checks and _not complete workflows_.
See #37 which should have all checks passed, but is waiting for checks that were skipped.

## Description

This PR makes Build and CodeQL job runs conditional in pull requests.
Czicompress-specific jobs are only run, when code that may affect czicompress is altered; and czishrink-specific jobs are only run for czishrink code changes.

Subproject changes are detected with a new [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) in subproject-changes.yml.

Goals: Simplify PR validation, reduce energy consumption.

Fixes #29 

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

 - PR.: 
   - #37
 - not PR: 
   - czishrink: [Manually triggered run of czishrink build on branch](https://github.com/ZEISS/czicompress/actions/runs/6968712198)
   - czicompress: [Manually triggered run of czicompress build on branch](https://github.com/ZEISS/czicompress/actions/runs/6968714621)

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
