### PR TITLE
Put TraceLoggerFactoryTests into non-parallel collection

### DIFF
--- a/czishrink/Directory.Build.props
+++ b/czishrink/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <!-- Version -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>1.1.1<!--dependabot/nuget/czishrink/SystemIOAbstractionsVersion-19.2.87--></VersionPrefix>
+    <VersionPrefix>1.1.2<!--feature/traceloggertests-to-non-parallel-collection--></VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/czishrink/netczicompressTests/AppComposerTests.cs
+++ b/czishrink/netczicompressTests/AppComposerTests.cs
@@ -12,12 +12,6 @@ using netczicompress;
 using netczicompress.ViewModels;
 
 /// <summary>
-/// Class to define test collection for <see cref="AppComposerTests"/>
-/// </summary>
-[CollectionDefinition(nameof(AppComposerTests), DisableParallelization = true)]
-public class AppComposerTestsCollection { }
-
-/// <summary>
 /// Tests for <see cref="AppComposer"/>.
 /// </summary>
 [Collection(nameof(AppComposerTests))]

--- a/czishrink/netczicompressTests/AppComposerTests.cs
+++ b/czishrink/netczicompressTests/AppComposerTests.cs
@@ -12,8 +12,15 @@ using netczicompress;
 using netczicompress.ViewModels;
 
 /// <summary>
+/// Class to define test collection for <see cref="AppComposerTests"/>
+/// </summary>
+[CollectionDefinition(nameof(AppComposerTests), DisableParallelization = true)]
+public class AppComposerTestsCollection { }
+
+/// <summary>
 /// Tests for <see cref="AppComposer"/>.
 /// </summary>
+[Collection(nameof(AppComposerTests))]
 public partial class AppComposerTests
 {
     [Fact]

--- a/czishrink/netczicompressTests/AppComposerTestsCollection.cs
+++ b/czishrink/netczicompressTests/AppComposerTestsCollection.cs
@@ -4,9 +4,8 @@
 
 namespace netczicompressTests
 {
-
     /// <summary>
-    /// Class to define test collection for <see cref="AppComposerTests"/>
+    /// Class to define test collection for <see cref="AppComposerTests"/>.
     /// </summary>
     [CollectionDefinition(nameof(AppComposerTests), DisableParallelization = true)]
     public class AppComposerTestsCollection

--- a/czishrink/netczicompressTests/AppComposerTestsCollection.cs
+++ b/czishrink/netczicompressTests/AppComposerTestsCollection.cs
@@ -1,0 +1,15 @@
+﻿// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace netczicompressTests
+{
+
+    /// <summary>
+    /// Class to define test collection for <see cref="AppComposerTests"/>
+    /// </summary>
+    [CollectionDefinition(nameof(AppComposerTests), DisableParallelization = true)]
+    public class AppComposerTestsCollection
+    {
+    }
+}

--- a/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
+++ b/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
@@ -9,9 +9,15 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// Tests for <see cref="TraceLoggerFactory"/>.
+/// Class to define test collection for <see cref="TraceLoggerFactoryTests"/>
 /// </summary>
 [CollectionDefinition(nameof(TraceLoggerFactoryTests), DisableParallelization = true)]
+public sealed class TraceLoggerFactoryTestsCollection {}
+
+/// <summary>
+/// Tests for <see cref="TraceLoggerFactory"/>.
+/// </summary>
+[Collection(nameof(TraceLoggerFactoryTests)]
 public sealed class TraceLoggerFactoryTests : IDisposable
 {
     private readonly MemoryTraceListener listener = new();

--- a/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
+++ b/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
@@ -9,15 +9,9 @@ using System.Text;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
-/// Class to define test collection for <see cref="TraceLoggerFactoryTests"/>
-/// </summary>
-[CollectionDefinition(nameof(TraceLoggerFactoryTests), DisableParallelization = true)]
-public sealed class TraceLoggerFactoryTestsCollection {}
-
-/// <summary>
 /// Tests for <see cref="TraceLoggerFactory"/>.
 /// </summary>
-[Collection(nameof(TraceLoggerFactoryTests)]
+[Collection(nameof(TraceLoggerFactoryTests))]
 public sealed class TraceLoggerFactoryTests : IDisposable
 {
     private readonly MemoryTraceListener listener = new();

--- a/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
+++ b/czishrink/netczicompressTests/Models/TraceLoggerFactoryTests.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 /// <summary>
 /// Tests for <see cref="TraceLoggerFactory"/>.
 /// </summary>
+[CollectionDefinition(nameof(TraceLoggerFactoryTests), DisableParallelization = true)]
 public sealed class TraceLoggerFactoryTests : IDisposable
 {
     private readonly MemoryTraceListener listener = new();

--- a/czishrink/netczicompressTests/Models/TraceLoggerFactoryTestsCollection.cs
+++ b/czishrink/netczicompressTests/Models/TraceLoggerFactoryTestsCollection.cs
@@ -1,0 +1,13 @@
+﻿// SPDX-FileCopyrightText: 2023 Carl Zeiss Microscopy GmbH
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+namespace netczicompressTests.Models;
+
+    /// <summary>
+    /// Class to define test collection for <see cref="TraceLoggerFactoryTests"/>.
+    /// </summary>
+    [CollectionDefinition(nameof(TraceLoggerFactoryTests), DisableParallelization = true)]
+    public sealed class TraceLoggerFactoryTestsCollection
+    {
+    }


### PR DESCRIPTION
## Description
There is an unstable test https://github.com/ZEISS/czicompress/actions/runs/6969814480/job/18966499474?pr=33 that is presumably caused by running our tests in parallel.

This change will move the TraceLoggerFactoryTests into their own collection with Parallelization disabled. This ought to run the other parallel-capable tests first and then run the TraceLoggerFactory tests sequentially. (see [https://xunit.net/docs/running-tests-in-parallel](https://xunit.net/docs/running-tests-in-parallel) for details)

- TraceLoggerFactoryTests and AppComposerTests have both been added to their own collection.
- External CollectionDefinition classes added for above classes

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

This has been tested locally and I will be keeping an eye on the actions for this PR as well to see if the issue in question is indeed resolved.

## Checklist:

- [X] I followed the Contributing Guidelines.
- [X] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [X] I updated the version of czicompress following [the README (Versioning)](../README.md#versioning) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
