### PR TITLE
Fix wrong decimal separator in CSV report in some locales

### DIFF
--- a/czishrink/Directory.Build.props
+++ b/czishrink/Directory.Build.props
@@ -17,6 +17,6 @@
 
     <!-- Version -->
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
-    <VersionPrefix>1.1.1<!--dependabot/nuget/czishrink/SystemIOAbstractionsVersion-19.2.87--></VersionPrefix>
+    <VersionPrefix>1.1.2<!--bugfix/decimal-sep--></VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/czishrink/netczicompress/Models/CsvLogFileWriter.cs
+++ b/czishrink/netczicompress/Models/CsvLogFileWriter.cs
@@ -8,6 +8,8 @@ using System;
 using System.Diagnostics;
 using System.IO;
 
+using static System.FormattableString;
+
 /// <summary>
 /// Writes a sequence of <see cref="CompressorMessage.FileFinished"/> messages to a CSV file.
 /// </summary>
@@ -45,16 +47,17 @@ public class CsvLogFileWriter : IObserver<CompressorMessage.FileFinished>
 
     private static string ToLine(CompressorMessage.FileFinished value)
     {
-        return string.Join(
-            ',',
-            Quote(value.InputFile.FullName),
-            value.SizeInput,
-            value.SizeOutput,
-            value.ErrorMessage == null ? value.SizeRatio : string.Empty,
-            value.ErrorMessage == null ? value.SizeDelta : string.Empty,
-            value.TimeElapsed?.ToString("c") ?? string.Empty,
-            value.ErrorMessage == null ? "SUCCESS" : "ERROR",
-            Quote(value.ErrorMessage)) + "\r\n";
+        return Invariant(
+                $"{
+                    Quote(value.InputFile.FullName)},{
+                    value.SizeInput},{
+                    value.SizeOutput},{
+                    (value.ErrorMessage == null ? value.SizeRatio : string.Empty)},{
+                    (value.ErrorMessage == null ? value.SizeDelta : string.Empty)},{
+                    value.TimeElapsed?.ToString("c") ?? string.Empty},{
+                    (value.ErrorMessage == null ? "SUCCESS" : "ERROR")},{
+                    Quote(value.ErrorMessage)}")
+                + "\r\n";
     }
 
     private static string Quote(string? value)


### PR DESCRIPTION
## Description

Use invariant formatting to write data and in particular decimal numbers to the CSV report.
Fixes #39 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran tests on a system with DE locale

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I updated the version of czicompress (PATCH)
- [x] New and existing unit tests pass locally with my changes.
