### PR TITLE
Adapt unit tests for PR 42 Add custom formatting for TimeSpan

### DIFF
--- a/czishrink/netczicompressTests/ViewModels/AggregateStatisticsViewModelTests.cs
+++ b/czishrink/netczicompressTests/ViewModels/AggregateStatisticsViewModelTests.cs
@@ -7,6 +7,7 @@ namespace netczicompressTests.ViewModels;
 using System.ComponentModel;
 
 using netczicompress.ViewModels;
+using netczicompress.ViewModels.Formatters;
 
 /// <summary>
 /// Tests for <see cref="AggregateStatisticsViewModel"/>.
@@ -23,7 +24,7 @@ public class AggregateStatisticsViewModelTests
         var sut = fixture.Create<AggregateStatisticsViewModel>();
 
         // ASSERT
-        sut.Should().BeEquivalentTo(AggregateStatistics.Empty, options => options.Excluding(o => o.Duration));
+        sut.Should().BeEquivalentTo(AggregateStatistics.Empty);
     }
 
     [Fact]
@@ -48,7 +49,7 @@ public class AggregateStatisticsViewModelTests
             Times.Once);
         propertyListener.VerifyNoOtherCalls();
 
-        sut.Should().BeEquivalentTo(newValue, options => options.Excluding(o => o.Duration));
+        sut.Should().BeEquivalentTo(newValue);
     }
 
     [Fact]
@@ -81,8 +82,15 @@ public class AggregateStatisticsViewModelTests
     {
         // ARRANGE
         IFixture fixture = CreateFixture();
+
+        var timeSpanFormatterMock = fixture.Freeze<Mock<ITimeSpanFormatter>>();
+        timeSpanFormatterMock
+            .Setup(x => x.FormatTimeSpan(It.IsAny<TimeSpan>()))
+            .Returns(string.Empty);
+
         var oldValue = fixture.Create<AggregateStatistics>();
         var sut = fixture.Create<AggregateStatisticsViewModel>();
+
         sut.OnNext(oldValue);
 
         // ACT
@@ -92,8 +100,8 @@ public class AggregateStatisticsViewModelTests
         // ASSERT
         monitor.OccurredEvents.Should().BeEmpty();
 
-        // Duration formatting is tested in <see cref="OnNext_WithNewDuration_HasNiceFormattedPropertySet"/>
-        sut.Should().BeEquivalentTo(oldValue, options => options.Excluding(o => o.Duration));
+        sut.Should().BeEquivalentTo(oldValue);
+        sut.FormattedDuration.Should().BeEquivalentTo(string.Empty);
     }
 
     private static IFixture CreateFixture()


### PR DESCRIPTION
## Description

There were some minor UT adaptations that I thought I had pushed before merging #42.

- Freeze Mock of ITimeFormatter to return empty string within `AggregateStatisticsViewModelTests` because we want to test invariant of formatting.
- Remove ShouldBeEquivalent options to ignore `Duration` when comparing `AggregateStatisticsViewModel` and `AggregateStatistics` record.

Fixes # (issue)

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Describe the tests that you ran to verify your changes.  
Provide instructions to reproduce.

## Checklist:

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [ ] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the version of czicompress following [the README (Versioning)](../README.md#versioning) depending on the [type of change](#type-of-change)
  - Bug fix -> PATCH
  - New feature -> MINOR
  - Breaking change -> MAJOR
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
