### PR TITLE
Group dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,18 @@ updates:
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      czishrink:
+        applies-to: version-updates
+        patterns:
+        - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "wednesday"
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       czishrink:
         applies-to: version-updates
         patterns:
-        - "*"
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -23,4 +23,4 @@ updates:
       github-actions:
         applies-to: version-updates
         patterns:
-        - "*"
+          - "*"


### PR DESCRIPTION
## Description

Group dependabot version updates to reduce the number of PRs. We need to manually update the package lock files and don't want to have to do this separately for each nuget.

See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

### Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.