### PR TITLE
Get dotnet version from global.json in github workflows

### DIFF
--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -44,6 +44,15 @@ runs:
       shell: bash
       working-directory: ${{inputs.src-dir}}
       run: |
+        # Temporary workaround for the vcpkg internal issue
+        # See https://github.com/microsoft/vcpkg/issues/41199#issuecomment-2378255699 for details
+        # shellcheck disable=SC2153
+        export SystemDrive=$SYSTEMDRIVE
+        # shellcheck disable=SC2153
+        export SystemRoot=$SYSTEMROOT
+        # shellcheck disable=SC2153
+        export windir=$WINDIR
+
         # We install the following packages: eigen3, catch2, cli11. Installing them with vcpkg (and caching them)
         # is faster than downloading and building them from source (which is the default behavior of the CZICompress-build-system).
         vcpkg install --triplet ${{inputs.platform}} eigen3 catch2 cli11

--- a/.github/workflows/czishrink_codeql.yml
+++ b/.github/workflows/czishrink_codeql.yml
@@ -37,10 +37,18 @@ jobs:
         with:
           lfs: true
 
+      - name: Get dotnet version from global.json
+        id: get_dotnet_version
+        run: |
+          $global_json = Get-Content -Path "./global.json" | ConvertFrom-Json
+          $dotnetversion = $global_json.sdk.version
+          "dotnetversion=$dotnetversion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        shell: pwsh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ steps.get_dotnet_version.outputs.dotnetversion }}
 
       - name: Cache nugets
         uses: actions/cache@v4

--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -41,10 +41,18 @@ jobs:
         with:
           lfs: true
 
+      - name: Get dotnet version from global.json
+        id: get_dotnet_version
+        run: |
+          $global_json = Get-Content -Path "./global.json" | ConvertFrom-Json
+          $dotnetversion = $global_json.sdk.version
+          "dotnetversion=$dotnetversion" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        shell: pwsh
+
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: ${{ steps.get_dotnet_version.outputs.dotnetversion }}
 
       - name: Get Version from Directory.Build.props
         id: getversion


### PR DESCRIPTION
## Description

* In the github workflows that build czishrink, get the dotnet SDK version from global.json. This will prevent them from breaking whenever a new release of the dotnet sdk becomes available in github.

* Add temporary workaround for vcpkg issue

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Run workflows in PR.

## Checklist

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.