### PR TITLE
Fix czishrink build by completely disabling roll-forward in global.json

### DIFF
--- a/.github/workflows/czishrink_dotnet.yml
+++ b/.github/workflows/czishrink_dotnet.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           dotnet-version: ${{ steps.get_dotnet_version.outputs.dotnetversion }}
 
+      - name: Print .NET version
+        run: dotnet --version
+
       - name: Get Version from Directory.Build.props
         id: getversion
         run: |

--- a/czishrink/global.json
+++ b/czishrink/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "8.0.401",
     "allowPrerelease": false,
-    "rollForward": "feature"
+    "rollForward": "disable"
   }
 }


### PR DESCRIPTION
## Description

* Print the dotnet version that is used to build czishrink.
* Change the roll-forward value in global.json to "disable", cf. https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#rollforward 

Fixes broken build

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
 PR build.

## Checklist

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
