### PR TITLE
Fix megalinter CPP warnings

### DIFF
--- a/czicompress/CMakeLists.txt
+++ b/czicompress/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_policy(SET CMP0091 NEW) # enable new "MSVC runtime library selection" (htt
 # Note that the CMake-variables <Projectname>_VERSION_MAJOR, <Projectname>_VERSION_MINOR, ... are defined by this statement,
 #  which are used in the build (so that - if changing the name here, change also the usage of those variables).
 project ("czicompress"
-         VERSION 0.5.3)
+         VERSION 0.5.4)
 
 set(czicompress_VERSION_PATCH_FLAGS "")
 set(czicompress_VERSION_TWEAK_FLAGS "")

--- a/czicompress/capi/capi.cpp
+++ b/czicompress/capi/capi.cpp
@@ -105,7 +105,7 @@ public:
               total_progress = 95 + 4 + 1 * phase_progress;
           }
 
-          return progress_report((int32_t)total_progress);
+          return progress_report(static_cast<int32_t>(total_progress));
         });
 
     writer->Close();

--- a/czicompress/lib/src/commandlineoptions.cpp
+++ b/czicompress/lib/src/commandlineoptions.cpp
@@ -7,7 +7,11 @@
 #include <CZICompress_Config.h>
 
 #include <CLI/CLI.hpp>
+#include <map>
+#include <memory>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "inc_libCZI.h"
 

--- a/czicompress/lib/src/consoleio.cpp
+++ b/czicompress/lib/src/consoleio.cpp
@@ -10,6 +10,7 @@
 #include <cstdarg>
 #include <iostream>
 #include <limits>
+#include <memory>
 
 #if CZICOMPRESS_WIN32_ENVIRONMENT
 #include <Windows.h>

--- a/czicompress/lib/src/copyczi.cpp
+++ b/czicompress/lib/src/copyczi.cpp
@@ -5,6 +5,8 @@
 #include "copyczi.h"
 
 #include <limits>
+#include <memory>
+#include <tuple>
 #include <utility>
 
 namespace

--- a/czicompress/lib/src/utils/utf8/platforms/posix/utf8converter.cpp
+++ b/czicompress/lib/src/utils/utf8/platforms/posix/utf8converter.cpp
@@ -6,6 +6,7 @@
 
 #include <codecvt>
 #include <locale>
+#include <string>
 
 namespace utils::utf8
 {

--- a/czicompress/lib/src/utils/utf8/platforms/windows/utf8converter.cpp
+++ b/czicompress/lib/src/utils/utf8/platforms/windows/utf8converter.cpp
@@ -7,6 +7,7 @@
 #include <include/utils/utf8/utf8converter.h>
 
 #include <stdexcept>
+#include <string>
 
 namespace utils::utf8
 {

--- a/czicompress/tests/libczi_utils.cpp
+++ b/czicompress/tests/libczi_utils.cpp
@@ -7,6 +7,7 @@
 #include <libCZI.h>
 
 #include <algorithm>
+#include <memory>
 
 CMemOutputStream::CMemOutputStream(size_t initial_size) : ptr_(nullptr), allocated_size_(initial_size), used_size_(0)
 {

--- a/czicompress/tests/test_commandlineparsing.cpp
+++ b/czicompress/tests/test_commandlineparsing.cpp
@@ -8,6 +8,7 @@
 #include <include/commandlineoptions.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <tuple>
 #include <vector>
 

--- a/czicompress/tests/test_utf8_utils.cpp
+++ b/czicompress/tests/test_utf8_utils.cpp
@@ -6,6 +6,7 @@
 #include <src/copyczi.h>
 
 #include <catch2/catch_test_macros.hpp>
+#include <string>
 
 #include "catch2/catch_all.hpp"
 #include "libczi_utils.h"


### PR DESCRIPTION
## Description

Fix the megalinter complaints of run https://github.com/ZEISS/czicompress/actions/runs/12010544734

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Run tests during build.

## Checklist

- [x] I followed the Contributing Guidelines.
- [x] I did a self-review.
- [x] I commented my code, particularly in hard-to-understand areas.
- [ ] I updated the documentation.
- [x] I updated the patch version of czicompress
- [x] Existing unit tests pass locally with my changes.
