### PR TITLE
Attempt to fix dependabot for nuget

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
       # FluentAssertions is non-free from version 8.0.0 onwards
       - dependency-name: "FluentAssertions"
         update-types: ["version-update:semver-major"]
+      # local package (not readable for dependabot if it's not using git lfs)
+      - dependency-name: "libczicompressc"
     groups:
       czishrink:
         applies-to: version-updates

--- a/czishrink/NuGet.config
+++ b/czishrink/NuGet.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Local" value="packages_local" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
This is another attempt to fix the failing dependabot updates for nuget.

Dependabot currently fails with
~~~
/usr/local/dotnet/current/sdk/8.0.403/NuGet.targets(174,5): error : End of Central Directory record could not be found. [/home/dependabot/dependabot-updater/repo/czishrink/netczicompress.Desktop/netczicompress.Desktop.csproj]
~~~

This looks like one of the nuget packages it is trying to restore is not a proper zip file.
One possible explanation is that it might bring its own nuget.config.
More likely, it doesn't use git lfs any more, and therefore the content of packages_local is a git lfs pointer instead of a zip file.

With this PR, we now 
* use explicit package sources
* exclude libczicompressc (the local nuget package) from dependabot

